### PR TITLE
feat: make plugin work with core 2.6

### DIFF
--- a/lib/consumers/transaction.js
+++ b/lib/consumers/transaction.js
@@ -7,7 +7,7 @@ const { Enums } = require('@arkecosystem/crypto')
 
 class TransactionConsumer {
   async process (transaction) {
-    if (transaction.type !== Enums.TransactionTypes.Vote) {
+    if (transaction.type !== Enums.TransactionType.Vote) {
       return
     }
     if (!this.__isSent(transaction.id)) {

--- a/lib/processors/transaction.js
+++ b/lib/processors/transaction.js
@@ -57,6 +57,9 @@ class TransactionProcessor {
      */
   async generateTransactions (transactions) {
     const txs = []
+    const relay = config.get('relays')[0]
+    const senderAddress = config.get('walletAddress')
+
     for (let transaction of transactions) {
       let tx = new Transaction(
         transaction.address,
@@ -64,6 +67,7 @@ class TransactionProcessor {
         config.get('vendorField')
       )
 
+      await tx.setNonce(relay, senderAddress) // Fetch and set proper nonce for Core 2.6
       tx.sign(config.get('walletPassphrase'), config.get('walletSecondPassphrase'))
       const txData = tx.data()
 

--- a/lib/utils/transaction.js
+++ b/lib/utils/transaction.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const axios = require('axios')
 const { Transactions } = require('@arkecosystem/crypto')
+const BigNumber = require('./bignumber')
 
 class Transaction {
   /**
@@ -10,11 +12,38 @@ class Transaction {
      * @param  {String} vendorField
      * @return {[type]}
      */
-  constructor (recipientId, amount, vendorField) {
+  constructor (recipientId, amount, vendorField, ) {
     this.transaction = Transactions.BuilderFactory.transfer()
       .recipientId(recipientId)
       .amount(amount)
       .vendorField(vendorField)
+      .version(2)
+  }
+
+  /**
+   * Sets the nonce of the transaction
+   */
+  async setNonce (relay, senderAddress) {
+    const nonce = await this.fetchNonce(relay, senderAddress)
+    this.transaction.nonce(BigNumber.new(nonce).plus(1))
+  }
+
+  /**
+   * Fetches the latest nonce from the API for the sending wallet
+   */
+  async fetchNonce (relay, senderAddress) {
+    const options = {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      url: `${relay}/api/wallets/${senderAddress}`
+    }
+    try {
+      const response = await axios(options)
+      return response.data.data.nonce
+    } catch (ex) {
+      // Could be a cold wallet
+      return "0";
+    }
   }
 
   /**


### PR DESCRIPTION
Changes for 2.6, might want to tag current version as `2.5` as this one will no longer work with that due to the addition of `nonces` and the updated `TransactionType` enum